### PR TITLE
Add explicit casts for visitor visit() return type

### DIFF
--- a/src/main/java/org/openrewrite/java/dropwizard/method/RemoveUnnecessaryOverride.java
+++ b/src/main/java/org/openrewrite/java/dropwizard/method/RemoveUnnecessaryOverride.java
@@ -63,7 +63,7 @@ public class RemoveUnnecessaryOverride extends Recipe {
                                 !TypeUtils.isOverride(m.getMethodType()) &&
                                 !(Boolean.TRUE.equals(ignoreAnonymousClassMethods) &&
                                         getCursorToParentScope(getCursor()).getValue() instanceof J.NewClass)) {
-                            return removeAnnotationVisitor.visit(m, ctx, getCursor().getParentTreeCursor());
+                            return (J.MethodDeclaration) removeAnnotationVisitor.visit(m, ctx, getCursor().getParentTreeCursor());
                         }
                         return m;
                     }


### PR DESCRIPTION
## Summary
- The `visit()` method on OpenRewrite visitors now returns `J` rather than the specific subtype
- Add explicit cast to `J.MethodDeclaration` in `RemoveUnnecessaryOverride.java`
- Fixes scheduled CI compilation failure

## Test plan
- [x] `./gradlew compileJava` passes
- [ ] `./gradlew test` (running)