### PR TITLE
Make MigrateToDropwizard5 test resilient to new 5.0.x patch releases

### DIFF
--- a/src/test/java/org/openrewrite/java/dropwizard/MigrateToDropwizard5Test.java
+++ b/src/test/java/org/openrewrite/java/dropwizard/MigrateToDropwizard5Test.java
@@ -104,7 +104,7 @@ class MigrateToDropwizard5Test implements RewriteTest {
     }
 
     @Test
-    void noChangeWhenAlreadyOnVersion5() {
+    void staysWithinDropwizard5x() {
         rewriteRun(
           //language=xml
           pomXml(
@@ -129,7 +129,14 @@ class MigrateToDropwizard5Test implements RewriteTest {
                       </dependencies>
                   </dependencyManagement>
               </project>
-              """
+              """,
+            // Already on Dropwizard 5; the recipe keeps the BOM on the latest 5.0.x patch
+            // (it may bump 5.0.1 to a newer 5.0.x release) without downgrading or breaking it.
+            spec -> spec.after(pom ->
+              assertThat(pom)
+                .contains("<artifactId>dropwizard-bom</artifactId>")
+                .containsPattern("<version>5\\.0\\.\\d+</version>")
+                .actual())
           )
         );
     }


### PR DESCRIPTION
## Problem

Scheduled CI started failing on 2026-06-01 ([run 26783650047](https://github.com/openrewrite/rewrite-dropwizard/actions/runs/26783650047)):

```
MigrateToDropwizard5Test > noChangeWhenAlreadyOnVersion5() FAILED
  AssertionFailedError: Expected recipe to complete in 0 cycles, but took at least one
  more cycle. Between the last two executed cycles there were changes to "pom.xml"
```

## Root cause

Not an upstream API break — this is **version drift**. The test pinned `dropwizard-bom` to `5.0.1` and expected the migration to be a no-op. But `MigrateToDropwizard5` runs:

```yaml
- org.openrewrite.java.dependencies.UpgradeDependencyVersion:
    groupId: io.dropwizard
    artifactId: "*"
    newVersion: "5.0.x"
```

which correctly bumps to the latest `5.0.x` patch. Once **Dropwizard 5.0.2** was released, the recipe upgraded `5.0.1` → `5.0.2`, so the "no change" expectation no longer held. Reproduced locally — the recipe output rewrites the BOM to `<version>5.0.2</version>`.

## Fix

The recipe behaviour is correct; the test was brittle. Assert that the BOM stays on **some** `5.0.x` version (rather than pinning a patch that drifts) and rename the test to `staysWithinDropwizard5x` to reflect the intent: an already-on-5 project keeps a valid 5.0.x BOM without downgrade or breakage.

Full `./gradlew test` passes locally.